### PR TITLE
Docs: Added ts-framework-sql repository link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Other external plugins and middlewares for this framework
 
     Redis based cache services for performance. Currently in closed alpha.
 
-- **ts-framework-sql (coming soon)**
+- **[ts-framework-sql](https://github.com/nxtep-io/ts-framework-sql)**
 
-    MySQL / Postgres database layer based on Sequelize. Currently in closed alpha.
+    MySQL / Postgres database layer based on TypeORM. Currently in  alpha.
 
 
 ## Documentation


### PR DESCRIPTION
Added ts-framework-sql repository link to the README as it's not in a closed alpha anymore