### PR TITLE
Feat: Recursively remove stack properties from errors.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,7 @@
         "--config=jest.json"
       ],
       "console": "integratedTerminal",
+      "sourceMaps": true,
       "internalConsoleOptions": "neverOpen",
     }
   ]

--- a/lib/error/ErrorReporter.ts
+++ b/lib/error/ErrorReporter.ts
@@ -3,6 +3,7 @@ import { BaseRequest, BaseResponse } from "../components/helpers/response";
 import { Logger, LoggerInstance } from "ts-framework-common";
 import { HttpServerErrors } from "./http/HttpCode";
 import HttpError from "./http/HttpError";
+import { stripStacks } from "./errorHelper";
 
 export interface ErrorReporterOptions {
   sentry?: Sentry.NodeClient;
@@ -58,7 +59,7 @@ export class ErrorReporter {
       this.logger.warn(error);
 
       if (this.options.omitStack) {
-        delete error.stack;
+        stripStacks(error);
       }
 
       // Respond with error
@@ -93,7 +94,7 @@ export class ErrorReporter {
     this.logger.error(serverError);
 
     if (this.options.omitStack) {
-      delete serverError.stack;
+      stripStacks(serverError);
     }
 
     // Respond with error

--- a/lib/error/errorHelper.ts
+++ b/lib/error/errorHelper.ts
@@ -19,6 +19,18 @@ function _stripStacksInternal(obj: any, clone: boolean): any {
   return output;
 }
 
+/**
+ * Recursively traverses an object and removes all stack properties in-place.
+ * @param obj The error or object to be stripped of stacks
+ */
 export function stripStacks<T extends any>(obj: T): T {
+  /*
+   * The second parameter controls wheter we return a new object or mutate the object in-place.
+   * If we choose to return a new object (which we should, since mutating parameters may lead to unpredictable
+   * consequences as the parameter object may live on and be passed to other places, and is generally frowned upon)
+   * we deep-clone the input object using fclone and mutate our clone, but fclone is intended for POJOs and does not
+   * preserve the prototype chain, so while this function was designed with the intention of not mutating its
+   * parameters, we are more scared of breaking the error prototype chain, so we mutate the object in place.
+   */
   return _stripStacksInternal(obj, false);
 }

--- a/lib/error/errorHelper.ts
+++ b/lib/error/errorHelper.ts
@@ -1,5 +1,24 @@
+import fclone from "fclone";
+
 const STACK_PROPERTY_NAME = "stack";
 
-export function stripStacks<T extends Error>(obj: T): T {
-  return obj;
+// tslint:disable-next-line
+function _stripStacksInternal(obj: any, clone: boolean): any {
+  const output = clone ? fclone(obj) : obj;
+
+  for (const prop of Object.getOwnPropertyNames(output)) {
+    const value = output[prop];
+
+    if (prop === STACK_PROPERTY_NAME) {
+      delete output[STACK_PROPERTY_NAME];
+    } else if (typeof value === "object" && value !== null) {
+      _stripStacksInternal(output[prop], false);
+    }
+  }
+
+  return output;
+}
+
+export function stripStacks<T extends any>(obj: T): T {
+  return _stripStacksInternal(obj, false);
 }

--- a/lib/error/errorHelper.ts
+++ b/lib/error/errorHelper.ts
@@ -1,0 +1,5 @@
+const STACK_PROPERTY_NAME = "stack";
+
+export function stripStacks<T extends Error>(obj: T): T {
+  return obj;
+}

--- a/tests/error/errorHelper.test.ts
+++ b/tests/error/errorHelper.test.ts
@@ -50,5 +50,20 @@ describe("lib.errors.errorHelper", () => {
       expect(errorWithNoStack.details).not.toHaveProperty("stack");
       expect(errorWithNoStack.details.bar).not.toHaveProperty("stack");
     });
+
+    it("Does not unset non-stack properties.", () => {
+      const httpError = new HttpError("TEST_ERROR", 500, {
+        stack: "foo",
+        otherProp: "foo",
+        bar: { stack: "baz", nestedOtherProp: "bar" }
+      });
+      const errorWithNoStack = stripStacks(httpError);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details.bar).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details.otherProp).toBe("foo");
+      expect(errorWithNoStack.details.bar.nestedOtherProp).toBe("bar");
+    });
   });
 });

--- a/tests/error/errorHelper.test.ts
+++ b/tests/error/errorHelper.test.ts
@@ -1,0 +1,54 @@
+import { stripStacks } from "../../lib/error/errorHelper";
+import { HttpError } from "../../lib";
+
+describe("lib.errors.errorHelper", () => {
+  describe("stripStacks", () => {
+    it("Removes the stack property from an error", () => {
+      const error = new Error("TEST_ERROR");
+      const errorWithNoStack = stripStacks(error);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+    });
+
+    it("Removes the stack property from an HttpError", () => {
+      const error = new HttpError("TEST_ERROR", 500);
+      const errorWithNoStack = stripStacks(error);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+    });
+
+    it("Removes stack properties from non-standard error fields", () => {
+      class MyError extends Error {
+        public details: any;
+
+        constructor(msg: string, details: any) {
+          super(msg);
+          this.details = details;
+        }
+      }
+
+      const myError = new MyError("TEST_ERROR", { stack: "foo" });
+      const errorWithNoStack = stripStacks(myError);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details).not.toHaveProperty("stack");
+    });
+
+    it("Removes stack properties in an HttpError's details", () => {
+      const httpError = new HttpError("TEST_ERROR", 500, { stack: "foo" });
+      const errorWithNoStack = stripStacks(httpError);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details).not.toHaveProperty("stack");
+    });
+
+    it("Removes deeply nested stacks.", () => {
+      const httpError = new HttpError("TEST_ERROR", 500, { stack: "foo", bar: { stack: "baz" } });
+      const errorWithNoStack = stripStacks(httpError);
+
+      expect(errorWithNoStack).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details).not.toHaveProperty("stack");
+      expect(errorWithNoStack.details.bar).not.toHaveProperty("stack");
+    });
+  });
+});

--- a/tests/error/server.errorReporter.test.ts
+++ b/tests/error/server.errorReporter.test.ts
@@ -139,44 +139,4 @@ describe("lib.server.errors.errorReporter", () => {
 
     await server.close();
   });
-
-  it("should remove deeply nested stacks on an error 404 if configured to omitStack", async () => {
-    // Initialize a simple server
-    const server = new Server({
-      port: 3333,
-      security: {
-        cors: false
-      },
-      router: {
-        omitStack: true,
-        routes: {
-          get: {
-            "/": (req, res) => {
-              const internalError = new Error("INTERNAL_ERROR");
-              throw new HttpError("TEST_ERROR", 404, {
-                message: internalError.message,
-                stack: internalError.stack
-              });
-            }
-          }
-        }
-      }
-    });
-
-    // Perform a simple request to get a 500 response
-    await request(server.app)
-      .get("/")
-      .expect("Content-Type", /json/)
-      .expect(500)
-      .then((response: any) => {
-        expect(response.body.status).toBe(500);
-        expect(response.body.stack).not.toBeDefined();
-        expect(response.body.stackId).toBeDefined();
-        expect(response.body.message).toMatch(/TEST_ERROR/);
-        expect(response.body.details.message).toMatch(/INTERNAL_ERROR/);
-        expect(response.body.details.stack).toBeUndefined();
-      });
-
-    await server.close();
-  });
 });


### PR DESCRIPTION
Changes the `errorReporter` implementation to recursively traverse the error object and delete all stack properties no matter how deeply nested the are (eg. in the details field) instead of only the topmost stack. Also adds an `errorHelper` module which exports the `stripStacks` helper function, but is not exported by the lib.