### PR TITLE
feat: propagate inflate option to body-parser middleware

### DIFF
--- a/lib/components/RequestComponent.ts
+++ b/lib/components/RequestComponent.ts
@@ -9,6 +9,7 @@ import Server from "../server";
 export interface RequestComponentOptions extends ComponentOptions {
   logger?: LoggerInstance;
   bodyLimit?: string;
+  inflate?: boolean;
   secret?: string;
   multer?: {
     single?: string;
@@ -36,14 +37,16 @@ export default class RequestComponent implements Component {
       // Text body
       server.app.use(
         bodyParser.text({
-          limit: this.options.bodyLimit
+          limit: this.options.bodyLimit,
+          inflate: this.options.inflate
         })
       );
 
       // JSON body
       server.app.use(
         bodyParser.json({
-          limit: this.options.bodyLimit
+          limit: this.options.bodyLimit,
+          inflate: this.options.inflate
         })
       );
 
@@ -51,6 +54,7 @@ export default class RequestComponent implements Component {
       server.app.use(
         bodyParser.urlencoded({
           limit: this.options.bodyLimit,
+          inflate: this.options.inflate,
           extended: true
         })
       );


### PR DESCRIPTION
The middleware `body-parser` accepts an option `inflate: boolean` which when set to true and the request has the header `Content-Encoding` populated it automatically handles decompressing the request body with the compression algorithm (gzip, brotli, deflate) specified by the `Content-Encoding` header.

There was no way to set this option when using ts-framework.
This MR adds an `inflate?: boolean` property to `RequestComponentOptions` which is adequately used to set the `inflate` option on `body-parser`.